### PR TITLE
Update wiki link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ kubejs/
 
 ### sounds.json
 
-[format description](https://minecraft.fandom.com/wiki/Sounds.json#File_structure)
+[format description](https://minecraft.wiki/w/Sounds.json#File_structure)
 
 ```json
 {


### PR DESCRIPTION
Hi, the minecarft community have stopped contributing to Fandom, so the most up-to-date changes will be on minecraft.wiki, it’s important to change as many links as possible to not confuse search engines.

Thank you so much if you are able to make this change :)